### PR TITLE
Add Arch Linux package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ germanium --no-window-access-bar -o main.png main.go
 
 You can download from [here](https://github.com/matsuyoshi30/germanium/releases).
 
+### Arch Linux
+
+```
+yay germanium
+```
+
 ### Build from source
 
 ```


### PR DESCRIPTION
I'm maintaining the Arch package for germanium and this pull requests add the installation description to the README for Arch Linux users.