### PR TITLE
feat: add alpha layer to colors and optimizations

### DIFF
--- a/util.go
+++ b/util.go
@@ -5,19 +5,54 @@ import (
 	"image/color"
 )
 
+func HexToByte(b byte) byte {
+	switch {
+	case b >= '0' && b <= '9':
+		return b - '0'
+	case b >= 'a' && b <= 'f':
+		return b - 'a' + 10
+	case b >= 'A' && b <= 'F':
+		return b - 'A' + 10
+	}
+
+	return 0
+}
+
 // ParseHexColor parses string into RGBA
 func ParseHexColor(s string) (color.RGBA, error) {
 	c := color.RGBA{A: 255}
 
 	var err error
+
+	// Remove hash if present
+	if s[0] == '#' {
+		s = s[1:]
+	}
+
+	// Parse color code
 	switch len(s) {
-	case 7:
-		_, err = fmt.Sscanf(s, "#%02x%02x%02x", &c.R, &c.G, &c.B)
+	case 8:
+		// RRGGBBAA
+		c.R = HexToByte(s[0])<<4 + HexToByte(s[1])
+		c.G = HexToByte(s[2])<<4 + HexToByte(s[3])
+		c.B = HexToByte(s[4])<<4 + HexToByte(s[5])
+		c.A = HexToByte(s[6])<<4 + HexToByte(s[7])
+	case 6:
+		// RRGGBB
+		c.R = HexToByte(s[0])<<4 + HexToByte(s[1])
+		c.G = HexToByte(s[2])<<4 + HexToByte(s[3])
+		c.B = HexToByte(s[4])<<4 + HexToByte(s[5])
 	case 4:
-		_, err = fmt.Sscanf(s, "#%1x%1x%1x", &c.R, &c.G, &c.B)
-		c.R *= 17
-		c.G *= 17
-		c.B *= 17
+		// RGBA
+		c.R = HexToByte(s[0]) * 17
+		c.G = HexToByte(s[1]) * 17
+		c.B = HexToByte(s[2]) * 17
+		c.A = HexToByte(s[3]) * 17
+	case 3:
+		// RGB
+		c.R = HexToByte(s[0]) * 17
+		c.G = HexToByte(s[1]) * 17
+		c.B = HexToByte(s[2]) * 17
 	default:
 		err = fmt.Errorf("invalid color length")
 	}


### PR DESCRIPTION
## Edits
- Add alpha layer to ParseHexColor to support transparency.  #35 
- Removed the `fmt.Sscanf`'s to parse the colors manually, the functions is now a lot quicker (~120 times quicker).

## Benchmark
```go
package germanium

import "testing"

func BenchmarkParseHexColorSixChars(b *testing.B) {
	for i := 0; i < b.N; i++ {
		ParseHexColor("#112233")
	}
}

func BenchmarkParseHexColorThreeChars(b *testing.B) {
	for i := 0; i < b.N; i++ {
		ParseHexColor("#123")
	}
}

func BenchmarkParseHexColorNewSixChars(b *testing.B) {
	for i := 0; i < b.N; i++ {
		ParseHexColorNew("#112233")
	}
}

func BenchmarkParseHexColorNewThreeChars(b *testing.B) {
	for i := 0; i < b.N; i++ {
		ParseHexColorNew("#123")
	}
}
```

```go
$ go test -bench . -benchmem
goos: linux
goarch: amd64
pkg: github.com/matsuyoshi30/germanium
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkParseHexColorSixChars-4        	 2143605	       563.7 ns/op	      76 B/op	       6 allocs/op
BenchmarkParseHexColorThreeChars-4      	 2545946	       463.5 ns/op	      68 B/op	       3 allocs/op
BenchmarkParseHexColorNewSixChars-4     	311080213	         3.852 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseHexColorNewThreeChars-4   	388633989	         3.100 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/matsuyoshi30/germanium	6.576s
```